### PR TITLE
Relative path fix. Does not work in every browser.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ artifacts/
 
 Source/Our.Umbraco.RedirectsViewer/.vs/
 Source/Our.Umbraco.TourEditor/.vs/config/
+/.vs
+/Source/Our.Umbraco.TourEditor/.vs/Our.Umbraco.TourEditor/v15/Server/sqlite3

--- a/Source/Our.Umbraco.TourEditor/Web/App_Plugins/TourEditor/scripts/controllers/edit-file-controller.js
+++ b/Source/Our.Umbraco.TourEditor/Web/App_Plugins/TourEditor/scripts/controllers/edit-file-controller.js
@@ -4,7 +4,7 @@
     function EditFileController($scope, $routeParams, editorState, appState, umbRequestHelper, navigationService, notificationsService, eventsService, tourResource) {
         var vm = this;
 
-        var subviewsPath = "~/App_Plugins/TourEditor/backoffice/toureditor/subviews/";
+        var subviewsPath = "/App_Plugins/TourEditor/backoffice/toureditor/subviews/";
 
         vm.page = {};
 


### PR DESCRIPTION
Works in Edge but does not in Chrome. 404 error was thrown trying launch. Removing "~" fixed the problem.